### PR TITLE
Add 'hidenames' privilege

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@ Minetest mod by Shara RedCat which adds two commands:
 1. '/hidenames' hides the nametags of all currently connected players.
 2. '/shownames' shows the name tags of all currently connected players.
 
+to use these commands, you need to have the 'hidenames' privilege, which you can grant with:
 
+`/grant <player> hidenames`
+
+server admins and single players automatically have this privilege.
 
 Licenses and Attribution 
 -----------------------

--- a/init.lua
+++ b/init.lua
@@ -1,7 +1,11 @@
+minetest.register_privilege("hidenames", {
+	description = "Can hide nametages",
+	give_to_singleplayer = true
+})
 
 minetest.register_chatcommand("hidenames", {
 	description = "Make all nametags invisible",
-	privs = {server = true},
+	privs = {hidenames = true},
 	func = function(name, param)
 		for _, player in pairs(minetest.get_connected_players()) do
 			player:set_nametag_attributes({color = {a = 0, r = 255, g = 255, b = 255}})
@@ -11,7 +15,7 @@ minetest.register_chatcommand("hidenames", {
 
 minetest.register_chatcommand("shownames", {
 	description = "Make all nametags visible",
-	privs = {server = true},
+	privs = {hidenames = true},
 	func = function(name, param)
 		for _, player in pairs(minetest.get_connected_players()) do
 			player:set_nametag_attributes({color = {a = 255, r = 255, g = 255, b = 255}})


### PR DESCRIPTION
enables non-server admins to hide names